### PR TITLE
fix#87: 방 나가기 시 입장했다는 시스템 메시지가 로비에서 출력되는 현상

### DIFF
--- a/server/include/Session.h
+++ b/server/include/Session.h
@@ -62,6 +62,7 @@ namespace Blokus::Server {
         bool isInLobby() const { return state_ == ConnectionState::InLobby; }
         bool isInRoom() const { return state_ == ConnectionState::InRoom; }
         bool isInGame() const { return state_ == ConnectionState::InGame; }
+        bool justLeftRoom() const { return justLeftRoom_; }
 
         // ���� Ȯ�� �Լ��� (����Ͻ� ������)
         bool canCreateRoom() const { return isInLobby(); }
@@ -72,9 +73,10 @@ namespace Blokus::Server {
 
         // ���� ���� �Լ���
         void setStateToConnected();
-        void setStateToLobby();
+        void setStateToLobby(bool fromRoom = false);
         void setStateToInRoom(int roomId = -1);
         void setStateToInGame();
+        void clearJustLeftRoomFlag() { justLeftRoom_ = false; }
 
         // ���� ����
         void setAuthenticated(const std::string& userId, const std::string& username);
@@ -119,6 +121,7 @@ namespace Blokus::Server {
         int currentRoomId_;
         std::atomic<bool> active_;
         std::chrono::steady_clock::time_point lastActivity_;
+        bool justLeftRoom_;
         
         // 사용자 계정 정보
         std::optional<UserAccount> userAccount_;

--- a/server/src/GameRoom.cpp
+++ b/server/src/GameRoom.cpp
@@ -789,6 +789,12 @@ namespace Blokus {
         void GameRoom::broadcastPlayerJoined(const std::string& username) {
             std::lock_guard<std::mutex> lock(m_playersMutex);
             
+            // 방에 플레이어가 1명뿐이면 브로드캐스트하지 않음 (방 생성자의 경우)
+            if (m_players.size() <= 1) {
+                spdlog::debug("🏠 방 {} 플레이어 입장 브로드캐스트 생략 (플레이어 1명, 방 생성자)", m_roomId);
+                return;
+            }
+            
             // 구조화된 메시지와 시스템 메시지 모두 전송
             broadcastMessageLocked("PLAYER_JOINED:" + username);
             

--- a/server/src/session.cpp
+++ b/server/src/session.cpp
@@ -20,6 +20,7 @@ namespace Blokus::Server {
         , currentRoomId_(-1)
         , active_(true)
         , lastActivity_(std::chrono::steady_clock::now())
+        , justLeftRoom_(false)
         , messageHandler_(nullptr)
         , writing_(false)
     {
@@ -139,17 +140,19 @@ namespace Blokus::Server {
         spdlog::debug("✅ 세션 상태 변경: {} -> 로그인 화면", sessionId_);
     }
 
-    void Session::setStateToLobby() {
+    void Session::setStateToLobby(bool fromRoom) {
         state_ = ConnectionState::InLobby;
         currentRoomId_ = -1;
+        justLeftRoom_ = fromRoom;
         updateLastActivity();
 
-        spdlog::debug("🏠 세션 상태 변경: {} -> 로비", sessionId_);
+        spdlog::debug("🏠 세션 상태 변경: {} -> 로비 (방에서 이동: {})", sessionId_, fromRoom);
     }
 
     void Session::setStateToInRoom(int roomId) {
         state_ = ConnectionState::InRoom;
         currentRoomId_ = roomId;
+        justLeftRoom_ = false;  // 방에 입장하면 플래그 리셋
         updateLastActivity();
 
         spdlog::debug("🏠 세션 상태 변경: {} -> 방 {}", sessionId_, roomId);


### PR DESCRIPTION
분석: 방 생성자 퇴장 시 잘못된 입장 메시지 원인 파악
추적: GameRoom 브로드캐스트가 로비 채팅으로 라우팅되는 원인
수정: 방 메시지가 로비로 잘못 라우팅되는 문제 해결
테스트: 방 생성자 퇴장 플로우 검증