### PR TITLE
fix#93: AFK한 유저가 돌아왔을 때 서버가 크래시 나는 현상

### DIFF
--- a/client/include/AfkNotificationDialog.h
+++ b/client/include/AfkNotificationDialog.h
@@ -54,6 +54,17 @@ namespace Blokus {
          * @brief 나가기 버튼 클릭 핸들러
          */
         void onLeaveGameClicked();
+        
+        /**
+         * @brief 게임 종료 시 호출되는 슬롯
+         * 모달이 열려있을 때 게임이 종료되면 자동으로 상태 변경
+         */
+        void onGameEnded();
+        
+        /**
+         * @brief AFK 해제 에러 처리 (게임이 이미 종료된 경우)
+         */
+        void onAfkUnblockError(const QString& reason, const QString& message);
 
     protected:
         /**
@@ -85,6 +96,9 @@ namespace Blokus {
         QString m_reason;
         int m_timeoutCount;
         int m_maxCount;
+        
+        // 게임 상태 추적
+        bool m_gameEnded;
     };
 
 } // namespace Blokus

--- a/client/include/GameBoard.h
+++ b/client/include/GameBoard.h
@@ -111,6 +111,13 @@ namespace Blokus {
         void focusInEvent(QFocusEvent* event) override;
         void focusOutEvent(QFocusEvent* event) override;
 
+    public slots:
+        // 게임 상태 변경 처리
+        void onGameEnded();
+        
+        // AFK 에러 처리
+        void onAfkUnblockError(const QString& reason, const QString& message);
+
     private slots:
         void onSceneChanged();
 

--- a/client/include/GameRoomWindow.h
+++ b/client/include/GameRoomWindow.h
@@ -195,6 +195,10 @@ namespace Blokus {
         // AFK 관련 슬롯
         void onAfkModeActivated(const QString& jsonData);
         void onAfkUnblockRequested();
+        
+        // AFK 관련 중계 슬롯 (GameBoard로 전달)
+        void onGameEndedForAfk();
+        void onAfkUnblockErrorForAfk(const QString& reason, const QString& message);
 
     private slots:
         void onGameStartClicked();

--- a/client/include/NetworkClient.h
+++ b/client/include/NetworkClient.h
@@ -5,6 +5,8 @@
 #include <QTimer>
 #include <QString>
 #include <QHostAddress>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <functional>
 #include <unordered_map>
 
@@ -153,6 +155,7 @@ namespace Blokus {
         void afkModeActivated(const QString& jsonData);
         void afkUnblockSuccess();
         void afkStatusReset(const QString& username);
+        void afkUnblockError(const QString& reason, const QString& message);
 
     private slots:
         void onConnected();

--- a/client/src/GameBoard.cpp
+++ b/client/src/GameBoard.cpp
@@ -1131,21 +1131,24 @@ namespace Blokus {
         m_afkDialog = new Blokus::AfkNotificationDialog(this);
         m_afkDialog->setAfkInfo(jsonObj);
         
-        // 시그널 연결
+        // 🔥 FIX: 시그널 연결 (AFK 해제 + 게임 종료 + 에러 처리)
         connect(m_afkDialog, &Blokus::AfkNotificationDialog::afkUnblockRequested, 
                 this, &GameBoard::afkUnblockRequested);
         
-        // 모달 대화상자 표시
-        int result = m_afkDialog->exec();
+        // 다이얼로그 닫힐 때 정리
+        connect(m_afkDialog, &QDialog::finished, [this]() {
+            if (m_afkDialog) {
+                m_afkDialog->deleteLater();
+                m_afkDialog = nullptr;
+            }
+        });
         
-        // 대화상자 정리
-        if (m_afkDialog) {
-            m_afkDialog->deleteLater();
-            m_afkDialog = nullptr;
-        }
+        // 🔥 FIX: non-modal로 표시 (exec() 대신 show() 사용)
+        m_afkDialog->show();
+        m_afkDialog->raise();
+        m_afkDialog->activateWindow();
         
-        // 결과에 따른 처리는 부모 컴포넌트에서 시그널을 통해 처리
-        qDebug() << "AFK 알림 대화상자 결과:" << result;
+        qDebug() << "AFK 알림 대화상자 표시 (non-modal)";
     }
     
     void GameBoard::showAfkNotification(int timeoutCount, int maxCount)
@@ -1160,20 +1163,42 @@ namespace Blokus {
         m_afkDialog = new Blokus::AfkNotificationDialog(this);
         m_afkDialog->setAfkInfo(timeoutCount, maxCount);
         
-        // 시그널 연결
+        // 🔥 FIX: 시그널 연결 (AFK 해제 + 게임 종료 + 에러 처리)
         connect(m_afkDialog, &Blokus::AfkNotificationDialog::afkUnblockRequested, 
                 this, &GameBoard::afkUnblockRequested);
         
-        // 모달 대화상자 표시
-        int result = m_afkDialog->exec();
+        // 다이얼로그 닫힐 때 정리
+        connect(m_afkDialog, &QDialog::finished, [this]() {
+            if (m_afkDialog) {
+                m_afkDialog->deleteLater();
+                m_afkDialog = nullptr;
+            }
+        });
         
-        // 대화상자 정리
+        // 🔥 FIX: non-modal로 표시 (exec() 대신 show() 사용)
+        m_afkDialog->show();
+        m_afkDialog->raise();
+        m_afkDialog->activateWindow();
+        
+        qDebug() << "AFK 알림 대화상자 표시 (non-modal)";
+    }
+
+    void GameBoard::onGameEnded()
+    {
+        // AFK 다이얼로그가 열려있으면 게임 종료 처리
         if (m_afkDialog) {
-            m_afkDialog->deleteLater();
-            m_afkDialog = nullptr;
+            m_afkDialog->onGameEnded();
+            qDebug() << "게임 종료로 인한 AFK 다이얼로그 상태 변경";
         }
-        
-        qDebug() << "AFK 알림 대화상자 결과:" << result;
+    }
+
+    void GameBoard::onAfkUnblockError(const QString& reason, const QString& message)
+    {
+        // AFK 다이얼로그가 열려있으면 에러 처리
+        if (m_afkDialog) {
+            m_afkDialog->onAfkUnblockError(reason, message);
+            qDebug() << QString("AFK 해제 에러 처리: %1 - %2").arg(reason, message);
+        }
     }
 
 } // namespace Blokus

--- a/client/src/GameRoomWindow.cpp
+++ b/client/src/GameRoomWindow.cpp
@@ -2562,6 +2562,26 @@ namespace Blokus {
         emit afkUnblockRequested();
     }
 
+    void GameRoomWindow::onGameEndedForAfk()
+    {
+        qDebug() << QString::fromUtf8("🏁 게임 종료로 인한 AFK 모달 처리");
+        
+        // GameBoard에 게임 종료 알림
+        if (m_gameBoard) {
+            m_gameBoard->onGameEnded();
+        }
+    }
+
+    void GameRoomWindow::onAfkUnblockErrorForAfk(const QString& reason, const QString& message)
+    {
+        qDebug() << QString::fromUtf8("❌ AFK 해제 에러로 인한 모달 처리: %1 - %2").arg(reason, message);
+        
+        // GameBoard에 AFK 에러 알림
+        if (m_gameBoard) {
+            m_gameBoard->onAfkUnblockError(reason, message);
+        }
+    }
+
 } // namespace Blokus
 
 #include "ui/GameRoomWindow.moc"

--- a/client/src/NetworkClient.cpp
+++ b/client/src/NetworkClient.cpp
@@ -785,6 +785,20 @@ namespace Blokus {
             emit afkStatusReset(username);
             qDebug() << QString::fromUtf8("AFK 상태 리셋 알림: %1").arg(username);
         }
+        else if (message.startsWith("AFK_UNBLOCK_ERROR:")) {
+            QString jsonData = message.mid(18); // "AFK_UNBLOCK_ERROR:" 제거
+            
+            // JSON 파싱
+            QJsonDocument doc = QJsonDocument::fromJson(jsonData.toUtf8());
+            if (doc.isObject()) {
+                QJsonObject obj = doc.object();
+                QString reason = obj["reason"].toString();
+                QString errorMessage = obj["message"].toString();
+                
+                emit afkUnblockError(reason, errorMessage);
+                qDebug() << QString::fromUtf8("AFK 해제 에러: %1 - %2").arg(reason, errorMessage);
+            }
+        }
     }
 
     // ========================================

--- a/client/src/main.cpp
+++ b/client/src/main.cpp
@@ -1274,7 +1274,16 @@ private:
                     m_gameRoomWindow, &Blokus::GameRoomWindow::onAfkModeActivated);
             connect(m_gameRoomWindow, &Blokus::GameRoomWindow::afkUnblockRequested,
                     m_networkClient, &Blokus::NetworkClient::sendAfkUnblock);
-            qDebug() << QString::fromUtf8("🚨 AFK 관련 시그널 연결 완료");
+            
+            // 🔥 FIX: 게임 종료 시 AFK 모달 처리 (GameRoomWindow를 통해 중계)
+            connect(m_networkClient, &Blokus::NetworkClient::gameEnded,
+                    m_gameRoomWindow, &Blokus::GameRoomWindow::onGameEndedForAfk);
+            
+            // 🔥 FIX: AFK 해제 에러 처리 (GameRoomWindow를 통해 중계)
+            connect(m_networkClient, &Blokus::NetworkClient::afkUnblockError,
+                    m_gameRoomWindow, &Blokus::GameRoomWindow::onAfkUnblockErrorForAfk);
+            
+            qDebug() << QString::fromUtf8("🚨 AFK 관련 시그널 연결 완료 (게임 종료 & 에러 처리 포함)");
 
             // 게임룸 채팅은 이미 전역적으로 연결되어 있음 (중복 연결 제거)
 

--- a/server/src/MessageHandler.cpp
+++ b/server/src/MessageHandler.cpp
@@ -2009,6 +2009,14 @@ namespace Blokus::Server
                 return;
             }
 
+            // 🔥 CRITICAL: 게임 상태 검증 추가 (crash 방지)
+            if (!room->isPlaying())
+            {
+                sendResponse("AFK_UNBLOCK_ERROR:{\"reason\":\"game_not_active\",\"message\":\"게임이 이미 종료되었습니다\"}");
+                spdlog::warn("⚠️ AFK 해제 시도하지만 게임이 종료됨: {} ({})", session_->getUsername(), session_->getUserId());
+                return;
+            }
+
             std::string userId = session_->getUserId();
             std::string username = session_->getUsername();
 


### PR DESCRIPTION
1단계: 서버측 Crash 방지 (최우선)
2단계: 모달을 진정한 Non-Modal로 변경
3단계: 게임 종료 시 자동 처리
4단계: 시그널 체인 연결