### PR TITLE
fix#93: AFK한 유저가 돌아왔을 때 서버가 크래시 나는 현상

### DIFF
--- a/server/include/GameRoom.h
+++ b/server/include/GameRoom.h
@@ -216,6 +216,10 @@ namespace Blokus {
             
             // 타이머 관련 내부 메서드
             void timeoutCheckLoop(); // 백그라운드 스레드에서 실행되는 타임아웃 체크 루프
+            
+            // 리소스 정리 헬퍼 메서드
+            void cleanupTimeoutThread(); // 타임아웃 스레드 안전 정리
+            void cleanupAfkStates(); // AFK 관련 상태 정리
         };
 
         // ========================================


### PR DESCRIPTION
게임이 끝났을 때 사용한 리소스 완전 정리
게임이 시작될 때 남아있는 리소스가 있었다면 해당 부분도 정리